### PR TITLE
Allow more complex contentType fields

### DIFF
--- a/src/plugins/jsonparser.coffee
+++ b/src/plugins/jsonparser.coffee
@@ -2,7 +2,7 @@ module.exports =
   processResponse: (res) ->
     # Check to see if the contentype is "something/json" or
     # "something/somethingelse+json"
-    if res.contentType and (/^.*\/(?:.*\+)?json$/i).test res.contentType
+    if res.contentType and (/^.*\/(?:.*\+)?json(;|\z)/i).test res.contentType
       # If the body hasn't been parsed yet, parse it.
       raw = if typeof res.body is 'string' then res.body else res.text
       res.body = JSON.parse raw if raw


### PR DESCRIPTION
When experimenting with the GitHub api (e.g. https://api.github.com/users/geelen) the `contentType` of the response is `application/json; charset=utf-8`. The regexp in `jsonparser` assumes `json` is the last token in that string, so this allows it to match `json;` or `json\z` (end of string).
