### PR TITLE
Add options object on the request object

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,13 @@ Those properties are:
             <code>abort()</code> call, its name will be <code>"Abort"</code>.
         </td>
     </tr>
+    <tr>
+        <td><code>options</code></td>
+        <td>
+            An object to hold any options that should be passed along for
+            use with plugins.
+        </td>
+    </tr>
 </table>
 
 

--- a/lib/request.js
+++ b/lib/request.js
@@ -10,6 +10,7 @@ function Request(optsOrUrl) {
   this.errorOn404 = opts.errorOn404 != null ? opts.errorOn404 : true;
   this.onload = opts.onload;
   this.onerror = opts.onerror;
+  this.options = opts.options || {};
 }
 
 Request.prototype.abort = function() {


### PR DESCRIPTION
I would like a way to specify some options to a plugin I wrote that are on a request by request basis. This will allow me to do that.

If there is another way you would like to achieve this, I am open to ideas. The ultimate goal is to allow the plugin to receive options in the `processRequest` method.
