### PR TITLE
Fix lib/xhr-browser.js 

### DIFF
--- a/lib/xhr-browser.js
+++ b/lib/xhr-browser.js
@@ -1,1 +1,0 @@
-module.exports = window.XMLHttpRequest;

--- a/lib/xhr-browser.js
+++ b/lib/xhr-browser.js
@@ -1,0 +1,3 @@
+if (typeof window !== 'undefined' && window !== null && window.XMLHttpRequest) {
+    module.exports = window.XMLHttpRequest;
+}


### PR DESCRIPTION
Add safety for when compiling with webpack and in other environments. 
